### PR TITLE
Créer la table issues et le modèle Issue

### DIFF
--- a/backend/app/models/issue.ts
+++ b/backend/app/models/issue.ts
@@ -1,0 +1,36 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import Audit from '#models/audit'
+
+export default class Issue extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare auditId: number
+
+  @column()
+  declare type: string
+
+  @column()
+  declare severity: string
+
+  @column()
+  declare element: string
+
+  @column()
+  declare description: string
+
+  @column()
+  declare recommendation: string | null
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime | null
+
+  @belongsTo(() => Audit)
+  declare audit: BelongsTo<typeof Audit>
+}

--- a/backend/database/migrations/1772303801280_create_issues_table.ts
+++ b/backend/database/migrations/1772303801280_create_issues_table.ts
@@ -1,0 +1,32 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'issues'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+
+      table
+        .integer('audit_id')
+        .unsigned()
+        .notNullable()
+        .references('id')
+        .inTable('audits')
+        .onDelete('CASCADE')
+
+      table.string('type').notNullable()
+      table.string('severity').notNullable()
+      table.text('element').notNullable()
+      table.text('description').notNullable()
+      table.text('recommendation').nullable()
+
+      table.timestamp('created_at').notNullable()
+      table.timestamp('updated_at').nullable()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}


### PR DESCRIPTION
Ce qui a été fait :

- Migration create_issues_table avec les colonnes : id, audit_id (FK), type, severity, element, description, recommendation, created_at, updated_at
- Modèle Issue avec relation belongsTo vers Audit
- Clé étrangère vers audits avec onDelete('CASCADE')
- Colonnes element, description et recommendation en type TEXT (contenu potentiellement long)
- Choix de string plutôt que enum pour type et severity (flexibilité avec Axe-core)

Closes #7