### PR TITLE
fix(database): correct column names and homogenize timestamps in audit migrations

### DIFF
--- a/backend/database/migrations/1772300984805_create_audits_table.ts
+++ b/backend/database/migrations/1772300984805_create_audits_table.ts
@@ -8,7 +8,7 @@ export default class extends BaseSchema {
       table.increments('id')
 
       table
-        .integer('projects_id')
+        .integer('project_id')
         .unsigned()
         .notNullable()
         .references('id')
@@ -18,9 +18,9 @@ export default class extends BaseSchema {
       table.float('score').nullable()
       table.json('raw_data').nullable()
 
-      table.timestamp('tested-at').nullable()
-      table.timestamp('created_at').notNullable()
-      table.timestamp('updated_at').nullable()
+      table.timestamp('tested_at').nullable()
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
     })
   }
 

--- a/backend/database/migrations/1772303801280_create_issues_table.ts
+++ b/backend/database/migrations/1772303801280_create_issues_table.ts
@@ -21,8 +21,8 @@ export default class extends BaseSchema {
       table.text('description').notNullable()
       table.text('recommendation').nullable()
 
-      table.timestamp('created_at').notNullable()
-      table.timestamp('updated_at').nullable()
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
     })
   }
 


### PR DESCRIPTION
## Contexte
En lisant les migrations pendant la décomposition du CRUD projets, deux fautes de nommage ont été repérées dans create_audits_table, ainsi qu'une incohérence de style sur les timestamps entre les migrations.

## Corrections de migration
1. create_audits_table : projects_id renommé en project_id pour respecter la convention Lucid de la relation belongsTo(Project). En l'état, la clé n'aurait pas été résolue automatiquement.
2. create_audits_table : tested-at renommé en tested_at. Le tiret était une anomalie dans un schéma sinon entièrement en snake_case, et un caractère à risque en SQL.
3. create_audits_table et create_issues_table : created_at et updated_at alignés sur le style de create_projects_table. La colonne métier tested_at reste nullable, un audit pouvant exister avant d'avoir été testé.

## Nettoyage
Le fichier database/schema.ts, généré automatiquement après chaque migration et marqué do-not-edit, était suivi par git par erreur. Il est retiré du suivi et ajouté au gitignore, de la même manière que le dossier .adonisjs. Il continue d'être régénéré localement.

## Vérification
Base régénérée via rollback puis run. Les cinq migrations sont completed et la base reflète les noms corrigés. Tables audits et issues vides, aucune donnée perdue.