### PR TITLE
feat(frontend): add project management and audit results UI

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -18,6 +18,12 @@ const router = createRouter({
       path: '/:pathMatch(.*)*',
       redirect: '/dashboard',
     },
+    {
+      path: '/projects/:id',
+      name: 'project-detail',
+      component: () => import('@/views/ProjectDetailView.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
 })
 

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -9,3 +9,25 @@ export type Project = {
   createdAt: string
   updatedAt: string
 }
+
+export type Issue = {
+  id: number
+  auditId: number
+  type: string
+  severity: string
+  element: string
+  description: string
+  recommendation: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type Audit = {
+  id: number
+  projectId: number
+  score: number | null
+  testedAt: string | null
+  createdAt: string
+  updatedAt: string
+  issues: Issue[]
+}

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -1,0 +1,11 @@
+/* Types des entites metier, refletant les structures renvoyees par l'API backend. */
+
+export type Project = {
+  id: number
+  userId: number
+  name: string
+  url: string
+  isPublic: boolean
+  createdAt: string
+  updatedAt: string
+}

--- a/frontend/src/views/DashBoardView.vue
+++ b/frontend/src/views/DashBoardView.vue
@@ -17,7 +17,25 @@
         </button>
       </div>
 
-      <div class="bg-white rounded-lg border border-gray-200 p-8 text-center">
+      <!-- Etat de chargement -->
+      <div v-if="isLoading" class="bg-white rounded-lg border border-gray-200 p-8 text-center">
+        <p class="text-gray-600">Chargement de tes projets...</p>
+      </div>
+
+      <!-- Etat d'erreur -->
+      <div
+        v-else-if="errorMessage"
+        class="bg-red-50 rounded-lg border border-red-200 p-8 text-center"
+      >
+        <p class="text-red-800 font-medium mb-2">Une erreur est survenue.</p>
+        <p class="text-red-700">{{ errorMessage }}</p>
+      </div>
+
+      <!-- Etat vide -->
+      <div
+        v-else-if="projects.length === 0"
+        class="bg-white rounded-lg border border-gray-200 p-8 text-center"
+      >
         <p class="text-gray-700 mb-2 font-medium">Tu n'as pas encore créé de projet.</p>
         <p class="text-gray-600 mb-6 max-w-md mx-auto">
           Un projet te permet de regrouper plusieurs audits dans le temps pour un même site web, et
@@ -30,13 +48,54 @@
           Créer mon premier projet
         </button>
       </div>
+
+      <!-- Liste des projets -->
+      <ul v-else class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <li
+          v-for="project in projects"
+          :key="project.id"
+          class="bg-white rounded-lg border border-gray-200 p-5 hover:border-primary-400 transition-colors"
+        >
+          <h3 class="font-semibold text-gray-900 mb-1">{{ project.name }}</h3>
+          <p class="text-sm text-gray-600 break-words">{{ project.url }}</p>
+        </li>
+      </ul>
     </section>
   </AppLayout>
 </template>
 
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
 import { useAuthStore } from '@/stores/auth'
+import { api } from '@/services/api'
+import type { Project } from '@/types/models'
+import type { ApiError } from '@/services/api'
 import AppLayout from '@/components/layout/AppLayout.vue'
 
 const authStore = useAuthStore()
+
+/* Etat reactif de la liste des projets et du cycle de chargement. */
+const projects = ref<Project[]>([])
+const isLoading = ref(true)
+const errorMessage = ref<string | null>(null)
+
+/* Charge les projets de l'utilisateur depuis l'API. Gere les trois etats : chargement, succes, erreur. */
+async function loadProjects() {
+  isLoading.value = true
+  errorMessage.value = null
+
+  try {
+    projects.value = await api.get<Project[]>('/api/projects')
+  } catch (error) {
+    const apiError = error as ApiError
+    errorMessage.value = apiError.errors[0]?.message ?? 'Impossible de charger les projets.'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+/* Au montage de la page, on declenche le chargement des projets. */
+onMounted(() => {
+  loadProjects()
+})
 </script>

--- a/frontend/src/views/DashBoardView.vue
+++ b/frontend/src/views/DashBoardView.vue
@@ -90,13 +90,14 @@
 
       <!-- Liste des projets -->
       <ul v-else class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <li
-          v-for="project in projects"
-          :key="project.id"
-          class="bg-white rounded-lg border border-gray-200 p-5 hover:border-primary-400 transition-colors"
-        >
-          <h3 class="font-semibold text-gray-900 mb-1">{{ project.name }}</h3>
-          <p class="text-sm text-gray-600 break-words">{{ project.url }}</p>
+        <li :key="project.id" v-for="project in projects">
+          <RouterLink
+            :to="`/projects/${project.id}`"
+            class="block bg-white rounded-lg border border-gray-200 p-5 hover:border-primary-400 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500"
+          >
+            <h3 class="font-semibold text-gray-900 mb-1">{{ project.name }}</h3>
+            <p class="text-sm text-gray-600 break-words">{{ project.url }}</p>
+          </RouterLink>
         </li>
       </ul>
     </section>
@@ -110,6 +111,7 @@ import { api } from '@/services/api'
 import type { Project } from '@/types/models'
 import type { ApiError } from '@/services/api'
 import AppLayout from '@/components/layout/AppLayout.vue'
+import { RouterLink } from 'vue-router'
 
 const authStore = useAuthStore()
 

--- a/frontend/src/views/DashBoardView.vue
+++ b/frontend/src/views/DashBoardView.vue
@@ -11,11 +11,56 @@
         <h2 class="text-xl font-bold text-gray-900">Mes projets</h2>
         <button
           type="button"
+          @click="toggleForm"
           class="bg-primary-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-primary-700 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
         >
-          Nouveau projet
+          {{ isFormVisible ? 'Annuler' : 'Nouveau projet' }}
         </button>
       </div>
+
+      <!-- Formulaire de creation, affiche au clic sur Nouveau projet -->
+      <form
+        v-if="isFormVisible"
+        @submit.prevent="submitForm"
+        class="bg-white rounded-lg border border-gray-200 p-5 mb-4"
+      >
+        <div class="mb-4">
+          <label for="project-name" class="block text-sm font-medium text-gray-700 mb-1">
+            Nom du projet
+          </label>
+          <input
+            id="project-name"
+            v-model="formName"
+            type="text"
+            required
+            class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+
+        <div class="mb-4">
+          <label for="project-url" class="block text-sm font-medium text-gray-700 mb-1">
+            URL du site à auditer
+          </label>
+          <input
+            id="project-url"
+            v-model="formUrl"
+            type="url"
+            required
+            placeholder="https://exemple.com"
+            class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+
+        <p v-if="formError" class="text-red-700 text-sm mb-4">{{ formError }}</p>
+
+        <button
+          type="submit"
+          :disabled="isSubmitting"
+          class="bg-primary-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-primary-700 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {{ isSubmitting ? 'Création...' : 'Créer le projet' }}
+        </button>
+      </form>
 
       <!-- Etat de chargement -->
       <div v-if="isLoading" class="bg-white rounded-lg border border-gray-200 p-8 text-center">
@@ -37,16 +82,10 @@
         class="bg-white rounded-lg border border-gray-200 p-8 text-center"
       >
         <p class="text-gray-700 mb-2 font-medium">Tu n'as pas encore créé de projet.</p>
-        <p class="text-gray-600 mb-6 max-w-md mx-auto">
+        <p class="text-gray-600 max-w-md mx-auto">
           Un projet te permet de regrouper plusieurs audits dans le temps pour un même site web, et
           de suivre l'évolution de son accessibilité.
         </p>
-        <button
-          type="button"
-          class="bg-primary-600 text-white px-6 py-3 rounded-md text-sm font-medium hover:bg-primary-700 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
-        >
-          Créer mon premier projet
-        </button>
       </div>
 
       <!-- Liste des projets -->
@@ -79,6 +118,13 @@ const projects = ref<Project[]>([])
 const isLoading = ref(true)
 const errorMessage = ref<string | null>(null)
 
+/* Etat reactif du formulaire de creation. */
+const isFormVisible = ref(false)
+const formName = ref('')
+const formUrl = ref('')
+const isSubmitting = ref(false)
+const formError = ref<string | null>(null)
+
 /* Charge les projets de l'utilisateur depuis l'API. Gere les trois etats : chargement, succes, erreur. */
 async function loadProjects() {
   isLoading.value = true
@@ -91,6 +137,42 @@ async function loadProjects() {
     errorMessage.value = apiError.errors[0]?.message ?? 'Impossible de charger les projets.'
   } finally {
     isLoading.value = false
+  }
+}
+
+/* Affiche ou masque le formulaire de creation. A la fermeture, on reinitialise les champs et l'erreur. */
+function toggleForm() {
+  isFormVisible.value = !isFormVisible.value
+  if (!isFormVisible.value) {
+    resetForm()
+  }
+}
+
+/* Reinitialise les champs du formulaire et l'erreur. */
+function resetForm() {
+  formName.value = ''
+  formUrl.value = ''
+  formError.value = null
+}
+
+/* Envoie le formulaire a l'API. En cas de succes, rafraichit la liste et ferme le formulaire. En cas d'erreur, affiche le message renvoye par l'API. */
+async function submitForm() {
+  isSubmitting.value = true
+  formError.value = null
+
+  try {
+    await api.post<Project>('/api/projects', {
+      name: formName.value,
+      url: formUrl.value,
+    })
+    resetForm()
+    isFormVisible.value = false
+    await loadProjects()
+  } catch (error) {
+    const apiError = error as ApiError
+    formError.value = apiError.errors[0]?.message ?? 'La création a échoué.'
+  } finally {
+    isSubmitting.value = false
   }
 }
 

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -1,0 +1,70 @@
+<!-- src/views/ProjectDetailView.vue -->
+<template>
+  <AppLayout>
+    <!-- Lien de retour vers le dashboard -->
+    <RouterLink
+      to="/dashboard"
+      class="text-sm text-primary-600 hover:text-primary-700 mb-6 inline-block"
+    >
+      &larr; Retour aux projets
+    </RouterLink>
+
+    <!-- Etat de chargement -->
+    <div v-if="isLoading" class="bg-white rounded-lg border border-gray-200 p-8 text-center">
+      <p class="text-gray-600">Chargement du projet...</p>
+    </div>
+
+    <!-- Etat d'erreur -->
+    <div v-else-if="errorMessage" class="bg-red-50 rounded-lg border border-red-200 p-8 text-center">
+      <p class="text-red-800 font-medium mb-2">Une erreur est survenue.</p>
+      <p class="text-red-700">{{ errorMessage }}</p>
+    </div>
+
+    <!-- Detail du projet -->
+    <div v-else-if="project">
+      <section class="mb-8">
+        <h1 class="text-2xl font-bold text-gray-900 mb-2">{{ project.name }}</h1>
+        <p class="text-gray-600 break-words">{{ project.url }}</p>
+      </section>
+    </div>
+  </AppLayout>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { RouterLink } from 'vue-router'
+import { api } from '@/services/api'
+import type { Project } from '@/types/models'
+import type { ApiError } from '@/services/api'
+import AppLayout from '@/components/layout/AppLayout.vue'
+
+/* Acces aux parametres de la route courante. route.params.id contient le segment dynamique de l'URL /projects/:id. */
+const route = useRoute()
+
+/* Etat reactif du projet et du cycle de chargement. */
+const project = ref<Project | null>(null)
+const isLoading = ref(true)
+const errorMessage = ref<string | null>(null)
+
+/* Charge le projet depuis l'API a partir de l'id present dans l'URL. */
+async function loadProject() {
+  isLoading.value = true
+  errorMessage.value = null
+
+  try {
+    const id = route.params.id
+    project.value = await api.get<Project>(`/api/projects/${id}`)
+  } catch (error) {
+    const apiError = error as ApiError
+    errorMessage.value = apiError.errors[0]?.message ?? 'Impossible de charger le projet.'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+/* Au montage, on charge le projet. */
+onMounted(() => {
+  loadProject()
+})
+</script>

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -5,7 +5,7 @@
       to="/dashboard"
       class="text-sm text-primary-600 hover:text-primary-700 mb-6 inline-block"
     >
-      &larr; Retour aux projets
+      Retour aux projets
     </RouterLink>
 
     <div v-if="isLoading" class="bg-white rounded-lg border border-gray-200 p-8 text-center">
@@ -32,39 +32,72 @@
         </button>
       </section>
 
-      <!-- Message d'attente pendant l'audit -->
-      <div
-        v-if="isAuditing"
-        class="bg-white rounded-lg border border-gray-200 p-6 text-center"
-      >
+      <div v-if="isAuditing" class="bg-white rounded-lg border border-gray-200 p-6 text-center">
         <p class="text-gray-600">
           Analyse de l'accessibilité en cours, cela peut prendre quelques secondes...
         </p>
       </div>
 
-      <!-- Erreur d'audit -->
-      <div
-        v-else-if="auditError"
-        class="bg-red-50 rounded-lg border border-red-200 p-6"
-      >
+      <div v-else-if="auditError" class="bg-red-50 rounded-lg border border-red-200 p-6">
         <p class="text-red-800 font-medium mb-1">L'audit a échoué.</p>
         <p class="text-red-700">{{ auditError }}</p>
       </div>
 
-      <!-- Confirmation brute du resultat, mise en forme a la sous-tache suivante -->
-      <div
-        v-else-if="audit"
-        class="bg-white rounded-lg border border-gray-200 p-6"
-      >
-        <p class="text-gray-900 font-medium">Audit terminé. Score : {{ audit.score }} sur 100.</p>
-        <p class="text-gray-600">{{ audit.issues.length }} violation(s) détectée(s).</p>
+      <div v-else-if="audit" class="space-y-6">
+        <section class="bg-white rounded-lg border border-gray-200 p-6">
+          <h2 class="text-lg font-semibold text-gray-900 mb-2">Score d'accessibilité</h2>
+          <p class="text-4xl font-bold" :class="scoreColorClass">{{ audit.score }} / 100</p>
+          <p class="text-gray-600 mt-2">
+            {{ audit.issues.length }} violation(s) détectée(s) sur la page analysée.
+          </p>
+        </section>
+
+        <section
+          v-if="audit.issues.length === 0"
+          class="bg-success-100 rounded-lg border border-success-600 p-6"
+        >
+          <p class="text-success-600 font-medium">
+            Aucune violation détectée. La page respecte les règles testées.
+          </p>
+        </section>
+
+        <section
+          v-for="group in groupedIssues"
+          :key="group.severity"
+          class="bg-white rounded-lg border border-gray-200 p-6"
+        >
+          <h3 class="text-base font-semibold mb-4" :class="group.titleClass">
+            {{ group.label }} ({{ group.issues.length }})
+          </h3>
+
+          <ul class="space-y-4">
+            <li
+              v-for="issue in group.issues"
+              :key="issue.id"
+              class="border-l-4 pl-4"
+              :class="group.borderClass"
+            >
+              <p class="font-medium text-gray-900 mb-1">{{ issue.description }}</p>
+              <pre class="bg-gray-100 text-gray-800 text-sm rounded p-2 my-2 overflow-x-auto">{{ issue.element }}</pre>
+              <a
+                v-if="issue.recommendation"
+                :href="issue.recommendation"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-sm text-primary-600 hover:text-primary-700 underline focus:outline-none focus:ring-2 focus:ring-primary-500"
+              >
+                Comment corriger ce problème
+              </a>
+            </li>
+          </ul>
+        </section>
       </div>
     </div>
   </AppLayout>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { RouterLink } from 'vue-router'
 import { api } from '@/services/api'
@@ -116,6 +149,38 @@ async function runAudit() {
     isAuditing.value = false
   }
 }
+
+/* Couleur du score selon trois seuils. Utilise les couleurs de statut definies dans le theme, dont le contraste est verifie. Seuils par defaut, affinables. */
+const scoreColorClass = computed(() => {
+  const score = audit.value?.score ?? 0
+  if (score >= 80) {
+    return 'text-success-600'
+  }
+  if (score >= 50) {
+    return 'text-warning-600'
+  }
+  return 'text-danger-600'
+})
+
+/* Ordre des gravites de la plus grave a la moins grave, avec leur libelle francais et les classes de couleur associees. critical et serious utilisent les couleurs de statut, moderate et minor restent neutres. */
+const severityConfig = [
+  { severity: 'critical', label: 'Critiques', titleClass: 'text-danger-600', borderClass: 'border-danger-600' },
+  { severity: 'serious', label: 'Sérieuses', titleClass: 'text-warning-600', borderClass: 'border-warning-600' },
+  { severity: 'moderate', label: 'Modérées', titleClass: 'text-gray-700', borderClass: 'border-gray-400' },
+  { severity: 'minor', label: 'Mineures', titleClass: 'text-gray-700', borderClass: 'border-gray-400' },
+]
+
+/* Regroupe les issues de l'audit par gravite, dans l'ordre defini. Ne garde que les groupes qui contiennent au moins une issue. */
+const groupedIssues = computed(() => {
+  const issues = audit.value?.issues ?? []
+
+  return severityConfig
+    .map((config) => ({
+      ...config,
+      issues: issues.filter((issue) => issue.severity === config.severity),
+    }))
+    .filter((group) => group.issues.length > 0)
+})
 
 /* Au montage, on charge le projet. */
 onMounted(() => {

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -1,7 +1,6 @@
 <!-- src/views/ProjectDetailView.vue -->
 <template>
   <AppLayout>
-    <!-- Lien de retour vers le dashboard -->
     <RouterLink
       to="/dashboard"
       class="text-sm text-primary-600 hover:text-primary-700 mb-6 inline-block"
@@ -9,23 +8,57 @@
       &larr; Retour aux projets
     </RouterLink>
 
-    <!-- Etat de chargement -->
     <div v-if="isLoading" class="bg-white rounded-lg border border-gray-200 p-8 text-center">
       <p class="text-gray-600">Chargement du projet...</p>
     </div>
 
-    <!-- Etat d'erreur -->
     <div v-else-if="errorMessage" class="bg-red-50 rounded-lg border border-red-200 p-8 text-center">
       <p class="text-red-800 font-medium mb-2">Une erreur est survenue.</p>
       <p class="text-red-700">{{ errorMessage }}</p>
     </div>
 
-    <!-- Detail du projet -->
     <div v-else-if="project">
       <section class="mb-8">
         <h1 class="text-2xl font-bold text-gray-900 mb-2">{{ project.name }}</h1>
-        <p class="text-gray-600 break-words">{{ project.url }}</p>
+        <p class="text-gray-600 break-words mb-6">{{ project.url }}</p>
+
+        <button
+          type="button"
+          @click="runAudit"
+          :disabled="isAuditing"
+          class="bg-primary-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-primary-700 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {{ isAuditing ? 'Audit en cours...' : 'Lancer un audit' }}
+        </button>
       </section>
+
+      <!-- Message d'attente pendant l'audit -->
+      <div
+        v-if="isAuditing"
+        class="bg-white rounded-lg border border-gray-200 p-6 text-center"
+      >
+        <p class="text-gray-600">
+          Analyse de l'accessibilité en cours, cela peut prendre quelques secondes...
+        </p>
+      </div>
+
+      <!-- Erreur d'audit -->
+      <div
+        v-else-if="auditError"
+        class="bg-red-50 rounded-lg border border-red-200 p-6"
+      >
+        <p class="text-red-800 font-medium mb-1">L'audit a échoué.</p>
+        <p class="text-red-700">{{ auditError }}</p>
+      </div>
+
+      <!-- Confirmation brute du resultat, mise en forme a la sous-tache suivante -->
+      <div
+        v-else-if="audit"
+        class="bg-white rounded-lg border border-gray-200 p-6"
+      >
+        <p class="text-gray-900 font-medium">Audit terminé. Score : {{ audit.score }} sur 100.</p>
+        <p class="text-gray-600">{{ audit.issues.length }} violation(s) détectée(s).</p>
+      </div>
     </div>
   </AppLayout>
 </template>
@@ -35,17 +68,21 @@ import { ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { RouterLink } from 'vue-router'
 import { api } from '@/services/api'
-import type { Project } from '@/types/models'
+import type { Project, Audit } from '@/types/models'
 import type { ApiError } from '@/services/api'
 import AppLayout from '@/components/layout/AppLayout.vue'
 
-/* Acces aux parametres de la route courante. route.params.id contient le segment dynamique de l'URL /projects/:id. */
 const route = useRoute()
 
 /* Etat reactif du projet et du cycle de chargement. */
 const project = ref<Project | null>(null)
 const isLoading = ref(true)
 const errorMessage = ref<string | null>(null)
+
+/* Etat reactif de l'audit. */
+const isAuditing = ref(false)
+const auditError = ref<string | null>(null)
+const audit = ref<Audit | null>(null)
 
 /* Charge le projet depuis l'API a partir de l'id present dans l'URL. */
 async function loadProject() {
@@ -60,6 +97,23 @@ async function loadProject() {
     errorMessage.value = apiError.errors[0]?.message ?? 'Impossible de charger le projet.'
   } finally {
     isLoading.value = false
+  }
+}
+
+/* Lance un audit sur le projet courant. L'analyse prend quelques secondes cote serveur, l'etat isAuditing permet d'afficher l'attente et de bloquer le bouton. */
+async function runAudit() {
+  isAuditing.value = true
+  auditError.value = null
+  audit.value = null
+
+  try {
+    const id = route.params.id
+    audit.value = await api.post<Audit>(`/api/projects/${id}/audits`)
+  } catch (error) {
+    const apiError = error as ApiError
+    auditError.value = apiError.errors[0]?.message ?? "L'audit a échoué."
+  } finally {
+    isAuditing.value = false
   }
 }
 


### PR DESCRIPTION
## Contexte
Construction du parcours frontend complet permettant d'utiliser le moteur d'audit depuis l'interface. Avant cette PR, le moteur d'audit n'était accessible que par appels API directs. Cette PR rend le parcours démontrable de bout en bout.

## Ce qui a été fait
- Liste des projets sur le dashboard, chargée depuis l'API avec gestion des états chargement, erreur et vide.
- Formulaire inline de création de projet, avec rafraîchissement de la liste au succès et affichage des erreurs de validation.
- Route et page de détail projet (/projects/:id), avec navigation depuis le dashboard. Le contrôle d'ownership du backend remonte en erreur si le projet n'appartient pas à l'utilisateur.
- Lancement d'un audit depuis la page détail, avec un état d'attente qui bloque le bouton et informe l'utilisateur pendant les quelques secondes d'analyse.
- Affichage des résultats : score sur 100 avec une couleur conditionnelle selon trois seuils, et violations regroupées par gravité de la plus grave à la moins grave, en français. Chaque violation montre sa description, l'élément HTML concerné, et un lien vers la documentation de correction.

## Choix techniques
- Types métier partagés (Project, Audit, Issue) dans un fichier dédié, reflétant les structures renvoyées par l'API.
- Réutilisation du service api existant pour tous les appels, avec injection automatique du token et gestion d'erreur centralisée.
- Les couleurs du score et des gravités réutilisent les couleurs de statut du thème, dont le contraste est vérifié, par cohérence avec la finalité d'accessibilité du projet.
- Création par formulaire inline plutôt que modal, par choix de maîtrise du code livré. Une modal accessible est identifiée comme amélioration.

## Limites connues, identifiées comme améliorations
- Affichage du dernier audit uniquement, l'historique des audits n'est pas encore présenté côté interface bien que le backend le permette.
- Pas de pagination ni de filtres sur les violations.
- Les erreurs d'audit dont l'origine est une URL injoignable s'affichent via un message générique, en lien avec le 500 backend déjà identifié.

## Rappel labels
frontend, feat